### PR TITLE
Delete LibSugar.pdb.meta

### DIFF
--- a/Runtime/LibSugar.pdb.meta
+++ b/Runtime/LibSugar.pdb.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 21784dc5bf7c3364c96d7702543ec73f
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
This metafile does not have a corresponding `LibSugar.pdb` file. This causes Unity to print a warning in the editor each time scripts are reloaded.